### PR TITLE
S3urlswithpath

### DIFF
--- a/classes/storages/s3/S3.php
+++ b/classes/storages/s3/S3.php
@@ -95,6 +95,16 @@ class S3 {
     public static $proxy = null;
 
     /**
+     * URL style for S3 requests
+     * Possible values: 'auto', 'virtual-hosted', 'path-style'
+     *
+     * @var string
+     * @access public
+     * @static
+     */
+    public static $urlStyle = 'auto';
+
+    /**
      * Use SSL validation?
      *
      * @var bool
@@ -1089,8 +1099,21 @@ class S3 {
 
         $uri = str_replace(array('%2F', '%2B'), array('/', '+'), rawurlencode($uri));
 
-        if ($hostBucket) {
-            $hostname = $bucket;
+        // Determine URL style based on S3::$urlStyle
+        $useVirtualHosted = false;
+        if (S3::$urlStyle === 'virtual-hosted') {
+            $useVirtualHosted = true;
+        } elseif (S3::$urlStyle === 'path-style') {
+            $useVirtualHosted = false;
+        } else {
+            // Auto-detect: use virtual-hosted if bucket name is DNS-compliant
+            $useVirtualHosted = preg_match('/^[a-z0-9][a-z0-9.-]*[a-z0-9]$/i', $bucket)
+                && !preg_match('/\.\./', $bucket)
+                && strlen($bucket) <= 63;
+        }
+
+        if ($useVirtualHosted) {
+            $hostname = $bucket . '.' . self::$endpoint;
             $canonicalUri = '/' . $uri;
         } else {
             $hostname = self::$endpoint;

--- a/classes/storages/s3/S3Request.php
+++ b/classes/storages/s3/S3Request.php
@@ -143,7 +143,18 @@ final class S3Request {
         //	$this->resource = $this->uri;
 
         if ($this->bucket !== '') {
-            if ($this->__dnsBucketName($this->bucket)) {
+            $useVirtualHosted = false;
+
+            if (S3::$urlStyle === 'virtual-hosted') {
+                $useVirtualHosted = true;
+            } elseif (S3::$urlStyle === 'path-style') {
+                $useVirtualHosted = false;
+            } else {
+                // Auto-detect based on bucket name DNS compliance
+                $useVirtualHosted = $this->__dnsBucketName($this->bucket);
+            }
+
+            if ($useVirtualHosted) {
                 $this->headers['Host'] = $this->bucket . '.' . $this->endpoint;
                 $this->resource = '/' . $this->bucket . $this->uri;
             } else {

--- a/classes/storages/s3/s3_file_system.php
+++ b/classes/storages/s3/s3_file_system.php
@@ -127,6 +127,12 @@ class s3_file_system extends storage_file_system implements i_file_system {
             $endpoint,
             $this->config->settings_s3_region
         );
+
+        // Set URL style based on setting
+        $urlStyle = get_config("local_alternative_file_system", "settings_s3generic_url_style");
+        if ($urlStyle && in_array($urlStyle, ['auto', 'virtual-hosted', 'path-style'])) {
+            S3::$urlStyle = $urlStyle;
+        }
     }
 
     /**

--- a/classes/storages/storage_file_system.php
+++ b/classes/storages/storage_file_system.php
@@ -218,7 +218,7 @@ class storage_file_system extends file_system {
             $cache->delete("destino_{$config->storage_destination}");
 
             return true;
-        } catch (dml_exception) {
+        } catch (dml_exception $e) {
             return false;
         }
     }

--- a/db/install.php
+++ b/db/install.php
@@ -23,6 +23,7 @@
  */
 function xmldb_local_alternative_file_system_install() {
     set_config("storage_destination", "", "local_alternative_file_system");
+    set_config("settings_s3generic_url_style", "auto", "local_alternative_file_system");
 
     return true;
 }

--- a/db/install.xml
+++ b/db/install.xml
@@ -10,7 +10,7 @@
             <FIELDS>
                 <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
                 <FIELD NAME="contenthash" TYPE="char" LENGTH="40" NOTNULL="true" SEQUENCE="false"/>
-                <FIELD NAME="storage" TYPE="char" LENGTH="5" NOTNULL="true" SEQUENCE="false"/>
+                <FIELD NAME="storage" TYPE="char" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
                 <FIELD NAME="timemodifield" TYPE="int" LENGTH="20" NOTNULL="true" SEQUENCE="false"/>
             </FIELDS>
             <KEYS>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -102,5 +102,20 @@ function xmldb_local_alternative_file_system_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2026021000, 'local', 'alternative_file_system');
     }
 
+    if ($oldversion < 2026050500) {
+        // Set default value for the new S3 URL style setting
+        $current = get_config("local_alternative_file_system", "settings_s3generic_url_style");
+        if ($current === false) {
+            set_config("settings_s3generic_url_style", "auto", "local_alternative_file_system");
+        }
+
+        $table = new xmldb_table('local_alternativefilesystemf');
+        $field = new xmldb_field('storage', XMLDB_TYPE_CHAR, '10', null, XMLDB_NOTNULL, null, null, 'contenthash');
+
+        $dbman->change_field_precision($table, $field);
+
+        upgrade_plugin_savepoint(true, 2026050500, 'local', 'alternative_file_system');
+    }
+
     return true;
 }

--- a/lang/en/local_alternative_file_system.php
+++ b/lang/en/local_alternative_file_system.php
@@ -54,6 +54,11 @@ $string['settings_s3generic_destino'] = 'Generic S3 (custom endpoint)';
 $string['settings_s3generic_endpoint'] = 'S3 endpoint URL';
 $string['settings_s3generic_endpoint_desc'] = 'The endpoint is the base address of your S3 service (an S3-compatible provider). You can enter it without <code>https://</code> and with or without the port. Do not include bucket names, nor only the service host (and port, if needed).<blockquote>Examples: <code>https://s3.eu-central-1.amazonaws.com</code>, <code>o000.idrivee.com</code> or <code>minio:9000</code>.<br>Do NOT use: <code><strong style="color:#673AB7;text-decoration:underline;">mybucket.</strong>s3.amazonaws.com</code> or <code>server:9000<strong style="color:#673AB7;text-decoration:underline;">/mybucket</strong></code>.</blockquote>';
 
+$string['settings_s3generic_url_style'] = 'S3 URL Style';
+$string['settings_s3generic_url_style_desc'] = 'Choose how the bucket name is included in the URL. "Virtual-hosted" puts the bucket in the domain (https://bucket.endpoint/uri). "Path-style" puts the bucket in the path (https://endpoint/bucket/uri). "Auto-detect" uses the bucket name format to decide.';
+$string['settings_s3generic_url_style_auto'] = 'Auto-detect (based on bucket name)';
+$string['settings_s3generic_url_style_virtual'] = 'Virtual-hosted (bucket in domain)';
+$string['settings_s3generic_url_style_path'] = 'Path-style (bucket in path)';
 
 $string['settings_success'] = '<strong>Data is correct.</strong><br>Please be cautious when modifying settings, as any incorrect changes can result in inaccessibility of stored files.';
 $string['storage_destination'] = 'Storage Destination';

--- a/settings/s3.php
+++ b/settings/s3.php
@@ -82,6 +82,19 @@ if (in_array($config->storage_destination, [ "s3generic"])) {
         PARAM_RAW_TRIMMED
     );
     $settings->add($setting);
+
+    $setting = new admin_setting_configselect(
+        "local_alternative_file_system/settings_s3generic_url_style",
+        get_string("settings_s3generic_url_style", "local_alternative_file_system"),
+        get_string("settings_s3generic_url_style_desc", "local_alternative_file_system"),
+        "auto",
+        [
+            "auto" => get_string("settings_s3generic_url_style_auto", "local_alternative_file_system"),
+            "virtual-hosted" => get_string("settings_s3generic_url_style_virtual", "local_alternative_file_system"),
+            "path-style" => get_string("settings_s3generic_url_style_path", "local_alternative_file_system"),
+        ]
+    );
+    $settings->add($setting);
 }
 
 $setting = new admin_setting_configtext(


### PR DESCRIPTION
Some s3 compatible remote storages can't work with urls in the style https://<bucker>.<domain>, using the url path to setup the bucket to use.

This pull request also fix an issue into the DB, where the limit for the storage is limited to 5 characters, that doesn't allow to store files that using the "s3generic" storage.